### PR TITLE
Fix schema for update_order_items tool

### DIFF
--- a/app/services/chat_service.py
+++ b/app/services/chat_service.py
@@ -160,7 +160,7 @@ TOOLS: List[Dict[str, Any]] = [
                         },
                     },
                 },
-                "required": ["order_id", "action"],
+                "required": ["order_id", "items"],
             },
         },
     },


### PR DESCRIPTION
## Summary
- correct the update_order_items schema to require `order_id` and `items`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68464ec037888328a313c9f5ca21f125