### PR TITLE
Add simple Hello FastAPI app

### DIFF
--- a/hello_app/main.py
+++ b/hello_app/main.py
@@ -1,0 +1,11 @@
+from fastapi import FastAPI
+
+app = FastAPI(title="Hello App", version="0.1.0")
+
+@app.get("/hello")
+async def say_hello():
+    return {"message": "Hello from the new app"}
+
+@app.get("/health")
+async def health():
+    return {"status": "ok"}


### PR DESCRIPTION
## Summary
- add a minimal FastAPI application in `hello_app`

## Testing
- `python -m py_compile hello_app/main.py`


------
https://chatgpt.com/codex/tasks/task_e_684689bf68fc832884b72ae40d3813c3